### PR TITLE
앨범 페이지 상세 세팅 + UT 피드백 적용

### DIFF
--- a/Yeowoo.xcodeproj/project.pbxproj
+++ b/Yeowoo.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		6556C3F72A6BA82B00B4EEE1 /* View+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6556C3F62A6BA82B00B4EEE1 /* View+.swift */; };
 		6556C3FB2A6E68C400B4EEE1 /* UINavigationController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6556C3FA2A6E68C400B4EEE1 /* UINavigationController+.swift */; };
 		6556C3FE2A6EB92600B4EEE1 /* FindFriendViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6556C3FD2A6EB92600B4EEE1 /* FindFriendViewModel.swift */; };
+		6556C4002A700E0600B4EEE1 /* CacheAsyncImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6556C3FF2A700E0600B4EEE1 /* CacheAsyncImage.swift */; };
 		65C076872A56F949003E6D92 /* YeowooApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C076862A56F949003E6D92 /* YeowooApp.swift */; };
 		65C076892A56F949003E6D92 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C076882A56F949003E6D92 /* ContentView.swift */; };
 		65C0768B2A56F94B003E6D92 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 65C0768A2A56F94B003E6D92 /* Assets.xcassets */; };
@@ -147,6 +148,7 @@
 		6556C3F62A6BA82B00B4EEE1 /* View+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+.swift"; sourceTree = "<group>"; };
 		6556C3FA2A6E68C400B4EEE1 /* UINavigationController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UINavigationController+.swift"; sourceTree = "<group>"; };
 		6556C3FD2A6EB92600B4EEE1 /* FindFriendViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindFriendViewModel.swift; sourceTree = "<group>"; };
+		6556C3FF2A700E0600B4EEE1 /* CacheAsyncImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheAsyncImage.swift; sourceTree = "<group>"; };
 		65C076832A56F949003E6D92 /* Yeowoo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Yeowoo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		65C076862A56F949003E6D92 /* YeowooApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YeowooApp.swift; sourceTree = "<group>"; };
 		65C076882A56F949003E6D92 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -250,6 +252,7 @@
 				65264BDB2A67C7BD009963E6 /* String+.swift */,
 				6556C3F62A6BA82B00B4EEE1 /* View+.swift */,
 				6556C3FA2A6E68C400B4EEE1 /* UINavigationController+.swift */,
+				6556C3FF2A700E0600B4EEE1 /* CacheAsyncImage.swift */,
 			);
 			path = Global;
 			sourceTree = "<group>";
@@ -840,6 +843,7 @@
 				106475212A6536D70092FE5B /* AlbumLayout.swift in Sources */,
 				1049B7F12A63F8BA0021F674 /* Font+.swift in Sources */,
 				65C077172A5BF4A7003E6D92 /* KeyChainAccount.swift in Sources */,
+				6556C4002A700E0600B4EEE1 /* CacheAsyncImage.swift in Sources */,
 				10CC160D2A64452300B27955 /* Buttons.swift in Sources */,
 				106475182A6529E40092FE5B /* MainView.swift in Sources */,
 				1064751A2A65331D0092FE5B /* NoAlbumLayout.swift in Sources */,

--- a/Yeowoo/CaesarComponents/View/Root/DemoMainView.swift
+++ b/Yeowoo/CaesarComponents/View/Root/DemoMainView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 // 메인뷰에 세팅
-class AppState: ObservableObject {
+final class AppState: ObservableObject {
 	@Published var moveToRootView: Bool = false
 }
 

--- a/Yeowoo/Sources/Global/CacheAsyncImage.swift
+++ b/Yeowoo/Sources/Global/CacheAsyncImage.swift
@@ -1,0 +1,61 @@
+//
+//  CacheAsyncImage.swift
+//  Yeowoo
+//
+//  Created by Kim SungHun on 2023/07/25.
+//
+
+import SwiftUI
+
+struct CacheAsyncImage<Content>: View where Content: View{
+	
+	private let url: URL
+	private let scale: CGFloat
+	private let transaction: Transaction
+	private let content: (AsyncImagePhase) -> Content
+	
+	init(
+		url: URL,
+		scale: CGFloat = 1.0,
+		transaction: Transaction = Transaction(),
+		@ViewBuilder content: @escaping (AsyncImagePhase) -> Content
+	){
+		self.url = url
+		self.scale = scale
+		self.transaction = transaction
+		self.content = content
+	}
+	
+	var body: some View{
+		if let cached = ImageCache[url]{
+			// let _ = print("cached: \(url.absoluteString)")
+			content(.success(cached))
+		}else{
+			// let _ = print("request: \(url.absoluteString)")
+			AsyncImage(
+				url: url,
+				scale: scale,
+				transaction: transaction
+			){phase in
+				cacheAndRender(phase: phase)
+			}
+		}
+	}
+	func cacheAndRender(phase: AsyncImagePhase) -> some View{
+		if case .success (let image) = phase {
+			ImageCache[url] = image
+		}
+		return content(phase)
+	}
+}
+fileprivate class ImageCache{
+	static private var cache: [URL: Image] = [:]
+	static subscript(url: URL) -> Image?{
+		get{
+			ImageCache.cache[url]
+		}
+		set{
+			ImageCache.cache[url] = newValue
+		}
+	}
+}

--- a/Yeowoo/Sources/Models/Album.swift
+++ b/Yeowoo/Sources/Models/Album.swift
@@ -45,7 +45,7 @@ struct ImagesEntity: Hashable {
     let url: String    // url
     let uploadUser: String    // 업로드 한 유저
     let roleCheck: Bool    // 역할 확인
-    let likeUsers: [String] // 좋아요 한 유저들
+    var likeUsers: [String] // 좋아요 한 유저들
     let uploadTime: String // 올린 시간 (수정한 시간)
 }
 

--- a/Yeowoo/Sources/Services/Firebase/FirebaseService.swift
+++ b/Yeowoo/Sources/Services/Firebase/FirebaseService.swift
@@ -288,7 +288,7 @@ struct FirebaseService {
 				} else {
 					storage.reference().child("album1/" + "\(fileName)").downloadURL { URL, error in
 						let dateFormatter = DateFormatter()
-						dateFormatter.dateFormat = "yyyy.MM.dd"
+						dateFormatter.dateFormat = "yyyy.MM.dd HH:mm:ss"
 						guard let URL else { return }
 						let updatedData: [String: Any] = [
 							// 수정

--- a/Yeowoo/Sources/ViewModels/AlbumViewModel.swift
+++ b/Yeowoo/Sources/ViewModels/AlbumViewModel.swift
@@ -144,4 +144,18 @@ final class AlbumViewModel: ObservableObject {
 													   albumDocId: "T9eJMPQEGQClFHEahX6r",
 													   fileName: String(describing: UUID()))
 	}
+	
+	/// sort
+	func imageSort(state: Bool) {
+		let formatter = DateFormatter()
+		formatter.dateFormat = "yyyy.MM.dd HH:mm:ss"
+		
+		images = images.map { $0.sorted { (img1, img2) -> Bool in
+			if let date1 = formatter.date(from: img1.uploadTime),
+			   let date2 = formatter.date(from: img2.uploadTime) {
+				return state ? date1 > date2 : date1 < date2
+			}
+			return false
+		}}
+	}
 }

--- a/Yeowoo/Sources/ViewModels/AlbumViewModel.swift
+++ b/Yeowoo/Sources/ViewModels/AlbumViewModel.swift
@@ -20,6 +20,12 @@ final class AlbumViewModel: ObservableObject {
 	@Published var images: [[ImagesEntity]] = []
 	@Published var albums: Album = Album()
 	
+	@Published var visibleImages: [[ImagesEntity]] = []
+	var tempVisibleImages: [[ImagesEntity]] = []
+	
+	@Published var visibleRoleImages: [[ImagesEntity]] = []
+	var tempVisibleRoleImages: [[ImagesEntity]] = []
+	
 	private var cancellables = Set<AnyCancellable>()
 	
 	/// 앨범 이미지 불러오기
@@ -51,9 +57,62 @@ final class AlbumViewModel: ObservableObject {
 					self.images.append(urls)
 				}
 				
+				self.visibleImages.removeAll()
+				self.visibleRoleImages.removeAll()
+				
+				self.tempVisibleImages = self.images
+				
 				self.fetchState = true
+				
+				self.nextFetchImages()
 			}
 			.store(in: &cancellables)
+	}
+	
+	@MainActor
+	func afterLikeFetch(entityIndex: Int, entity: ImagesEntity) {
+		if let index = visibleImages[entityIndex].firstIndex(where: { $0.fileName == entity.fileName }) {
+			visibleImages[entityIndex][index] = entity
+		}
+	}
+	
+	@MainActor
+	func nextFetchImages() {
+		if !tempVisibleImages.isEmpty {
+			visibleImages.append(tempVisibleImages.removeFirst())
+		}
+	}
+	
+	/// 역할 클릭
+	@MainActor
+	func fetchAlbumUserImages(uploadUserId: String) {
+		visibleRoleImages.removeAll()
+		roleImage.removeAll()
+		var urls: [ImagesEntity] = []
+		images.forEach { imageEntitys in
+			imageEntitys.forEach { imageEntity in
+				if imageEntity.uploadUser == uploadUserId && imageEntity.roleCheck {
+					urls.append(imageEntity)
+					if urls.count == 5 {
+						roleImage.append(urls)
+						urls.removeAll()
+					}
+				}
+			}
+		}
+		if !urls.isEmpty {
+			roleImage.append(urls)
+		}
+		
+		self.tempVisibleRoleImages = roleImage
+		self.nextFetchRoleImages()
+	}
+	
+	@MainActor
+	func nextFetchRoleImages() {
+		if !tempVisibleRoleImages.isEmpty {
+			visibleRoleImages.append(tempVisibleRoleImages.removeFirst())
+		}
 	}
 	
 	/// 유저 불러오기
@@ -71,27 +130,6 @@ final class AlbumViewModel: ObservableObject {
 				self.users = user
 			}
 			.store(in: &cancellables)
-	}
-	
-	/// 역할 클릭
-	@MainActor
-	func fetchAlbumUserImages(uploadUserId: String) {
-		roleImage.removeAll()
-		var urls: [ImagesEntity] = []
-		images.forEach { imageEntitys in
-			imageEntitys.forEach { imageEntity in
-				if imageEntity.uploadUser == uploadUserId && imageEntity.roleCheck {
-					urls.append(imageEntity)
-					if urls.count == 5 {
-						roleImage.append(urls)
-						urls.removeAll()
-					}
-				}
-			}
-		}
-		if !urls.isEmpty {
-			roleImage.append(urls)
-		}
 	}
 	
 	/// 좋아요 클릭
@@ -150,7 +188,15 @@ final class AlbumViewModel: ObservableObject {
 		let formatter = DateFormatter()
 		formatter.dateFormat = "yyyy.MM.dd HH:mm:ss"
 		
-		images = images.map { $0.sorted { (img1, img2) -> Bool in
+		visibleImages = visibleImages.map { $0.sorted { (img1, img2) -> Bool in
+			if let date1 = formatter.date(from: img1.uploadTime),
+			   let date2 = formatter.date(from: img2.uploadTime) {
+				return state ? date1 > date2 : date1 < date2
+			}
+			return false
+		}}
+		
+		visibleRoleImages = visibleRoleImages.map { $0.sorted { (img1, img2) -> Bool in
 			if let date1 = formatter.date(from: img1.uploadTime),
 			   let date2 = formatter.date(from: img2.uploadTime) {
 				return state ? date1 > date2 : date1 < date2

--- a/Yeowoo/Sources/Views/Album/AlbumDetailView.swift
+++ b/Yeowoo/Sources/Views/Album/AlbumDetailView.swift
@@ -22,8 +22,9 @@ struct AlbumDetailView: View {
 	
 	@Environment(\.dismiss) var dismiss
 	
-	private var entitys: ImagesEntity
+	@State private var entitys: ImagesEntity
 	private var user: User
+	private var entityIndex: Int
 	
 	@ObservedObject private var viewModel: AlbumViewModel
 	
@@ -31,9 +32,10 @@ struct AlbumDetailView: View {
 	@State private var tempLikeCount: Int
 	@State private var alertType: AlertType? = nil
 	
-	init(entitys: ImagesEntity, user: User,
+	init(entityIndex: Int, entitys: ImagesEntity, user: User,
 		 tempLikeState: Bool, tempLikeCount: Int, viewModel: AlbumViewModel) {
-		self.entitys = entitys
+		self.entityIndex = entityIndex
+		self._entitys = State(initialValue: entitys)
 		self.user = user
 		self._tempLikeState = State(initialValue: tempLikeState)
 		self._tempLikeCount = State(initialValue: tempLikeCount)
@@ -53,10 +55,20 @@ struct AlbumDetailView: View {
 		}
 		.navigationBarTitle("")
 		.navigationBarHidden(true)
+		.onAppear {
+			viewModel.likeChk = false
+		}
 		.onDisappear {
 			if viewModel.likeChk {
 				Task {
-					viewModel.fetchAlbumImages(albumDocId: viewModel.albums.id)
+					if tempLikeState {
+						entitys.likeUsers.append(UserDefaultsSetting.userDocId)
+					} else {
+						if let index = entitys.likeUsers.firstIndex(of: UserDefaultsSetting.userDocId) {
+								entitys.likeUsers.remove(at: index)
+							}
+					}
+					viewModel.afterLikeFetch(entityIndex: entityIndex, entity: entitys)
 				}
 			}
 		}

--- a/Yeowoo/Sources/Views/Album/AlbumDetailView.swift
+++ b/Yeowoo/Sources/Views/Album/AlbumDetailView.swift
@@ -74,7 +74,7 @@ private extension AlbumDetailView {
 					dismiss()
 				}
 			Spacer()
-			Text("\(entitys.uploadTime)")
+			Text(getFormattedDateString(entitys.uploadTime))
 				.font(.system(size: 18))
 				.fontWeight(.semibold)
 			Spacer()
@@ -236,5 +236,11 @@ private extension AlbumDetailView {
 			.foregroundColor(Color.black)
 			.padding(.horizontal, 20)
 		Spacer()
+	}
+	
+	func getFormattedDateString(_ dateString: String) -> String {
+		let startIndex = dateString.startIndex
+		let endIndex = dateString.index(startIndex, offsetBy: 10)
+		return String(dateString[startIndex..<endIndex])
 	}
 }

--- a/Yeowoo/Sources/Views/Album/AlbumFeedView.swift
+++ b/Yeowoo/Sources/Views/Album/AlbumFeedView.swift
@@ -187,34 +187,37 @@ private extension AlbumFeedView {
 						Button(action: {
 							profileRoleChanged(index: index)
 						}) {
-							AsyncImage(url: URL(string: viewModel.users[index].profileImage)) { image in
-								image
-									.resizable()
-									.aspectRatio(contentMode: .fill)
-									.frame(width: 70, height: 84)
-									.cornerRadius(20)
-									.padding(5)
-									.overlay {
-										RoundedRectangle(cornerRadius: 20)
-											.stroke(Color.mainColor, lineWidth: 2)
-											.padding(2)
-									}
-									.overlay (
-										(
-											roleState == .all || nowSelectedUser?.docId != viewModel.users[index].docId
-											? nil : Image("chk").frame(width: 24, height: 24)
+							CacheAsyncImage(url: URL(string: viewModel.users[index].profileImage)!) { phase in
+								switch phase {
+								case .success(let image):
+									image
+										.resizable()
+										.aspectRatio(contentMode: .fill)
+										.frame(width: 70, height: 84)
+										.cornerRadius(20)
+										.padding(5)
+										.overlay {
+											RoundedRectangle(cornerRadius: 20)
+												.stroke(Color.mainColor, lineWidth: 2)
+												.padding(2)
+										}
+										.overlay (
+											(
+												roleState == .all || nowSelectedUser?.docId != viewModel.users[index].docId
+												? nil : Image("chk").frame(width: 24, height: 24)
+											)
+											,alignment: .topTrailing
 										)
-										,alignment: .topTrailing
-									)
-									.overlay (
-										Image("\(viewModel.albums.role[index])")
-											.frame(width: 38, height: 38)
-											.padding(.top, 80)
-									)
-								
-							} placeholder: {
-								ProgressView()
-									.frame(width: 70, height: 84)
+										.overlay (
+											Image("\(viewModel.albums.role[index])")
+												.frame(width: 38, height: 38)
+												.padding(.top, 80)
+										)
+									
+								default:
+									ProgressView()
+										.frame(width: 70, height: 84)
+								}
 							}
 						}
 						Spacer().frame(height: 15)

--- a/Yeowoo/Sources/Views/Album/AlbumFeedView.swift
+++ b/Yeowoo/Sources/Views/Album/AlbumFeedView.swift
@@ -41,34 +41,49 @@ struct AlbumFeedView: View {
 			
 			CustomNavigationBar()
 			
-			ScrollView(showsIndicators: false) {
-				VStack {
-					
-					ProfileCarouselView()
-					
-					Spacer()
-						.frame(height: 24)
-					Divider()
-					
-					// sort 임시 토글
-					Toggle(isOn: self.$testSortToggle) { }
-						.onChange(of: testSortToggle) { newValue in
-							viewModel.imageSort(state: newValue)
-						}
-					
-					LazyVStack(pinnedViews: [.sectionHeaders]){
-						Section {
-							ImageView()
-						} header: {
-							HStack {
-								Toggle(isOn: self.$layoutToggleState) {
-									Text((roleState == .all ? "All" : self.nowSelectedUser?.nickname)!)
-								}
-								.toggleStyle(CheckmarkToggleStyle())
-								.padding(.horizontal)
+			ScrollViewReader { proxy in
+				ScrollView(showsIndicators: false) {
+					VStack {
+						
+						ProfileCarouselView()
+							.id("scroll_to_top")
+						
+						Spacer()
+							.frame(height: 24)
+						Divider()
+						
+						// sort 임시 토글
+						Toggle(isOn: self.$testSortToggle) { }
+							.onChange(of: testSortToggle) { newValue in
+								viewModel.imageSort(state: newValue)
 							}
-							.frame(height: 40)
-							.background(Color.white)
+						
+						LazyVStack(pinnedViews: [.sectionHeaders]){
+							Section {
+								ImageView()
+							} header: {
+								HStack {
+									Toggle(isOn: self.$layoutToggleState) {
+										Text((roleState == .all ? "All" : self.nowSelectedUser?.nickname)!)
+									}
+									.onChange(of: layoutToggleState, perform: { _ in
+										withAnimation(.default) {
+											proxy.scrollTo("scroll_to_top", anchor: .top)
+										}
+									})
+									.toggleStyle(CheckmarkToggleStyle())
+									.padding(.horizontal)
+								}
+								.frame(height: 40)
+								.background(Color.white)
+							}
+							if roleState == .all ? (!viewModel.tempVisibleImages.isEmpty)
+								: (!viewModel.tempVisibleRoleImages.isEmpty) {
+								ProgressView()
+									.onAppear {
+										roleState == .all ? viewModel.nextFetchImages() : viewModel.nextFetchRoleImages()
+									}
+							}
 						}
 					}
 				}
@@ -286,7 +301,7 @@ private extension AlbumFeedView {
 	
 	@ViewBuilder
 	func ImageView() -> some View {
-		if roleState == .all && (viewModel.images.isEmpty || viewModel.images[0].count == 0) {
+		if roleState == .all && (viewModel.visibleImages.isEmpty || viewModel.visibleImages[0].count == 0) {
 			VStack {
 				Text("첫 번째 사진을 올려보세요!")
 				Text("카메라로 사진을 찍어 첫 추억을 남겨보세요")
@@ -297,7 +312,8 @@ private extension AlbumFeedView {
 				.padding(.top, UIScreen.main.bounds.height / 3.5)
 		} else {
 			VStack(spacing: layoutToggleState ? 0 : 2) {
-				ForEach(roleState == .all ? viewModel.images.indices : viewModel.roleImage.indices, id: \.self) { index in
+				ForEach(roleState == .all ? viewModel.visibleImages.indices
+						: viewModel.visibleRoleImages.indices, id: \.self) { index in
 					setLayout(index: index)
 				}
 			}
@@ -309,31 +325,37 @@ private extension AlbumFeedView {
 		if layoutToggleState {
 			if roleState == .all {
 				GalleryLayout(viewModel: viewModel,
-							  entitys: viewModel.images[index],
-							  user: viewModel.users)
+							  entitys: viewModel.visibleImages[index],
+							  user: viewModel.users,
+							  entityIndex: index)
 			} else {
 				GalleryLayout(viewModel: viewModel,
-							  entitys: viewModel.roleImage[index],
-							  user: viewModel.users)
+							  entitys: viewModel.visibleRoleImages[index],
+							  user: viewModel.users,
+							  entityIndex: index)
 			}
 		} else {
 			if index % 3 == 1 {
 				if roleState == .all {
-					FirstFeedLayout(entitys: viewModel.images[index],
+					FirstFeedLayout(entityIndex: index,
+									entitys: viewModel.visibleImages[index],
 									user: viewModel.users,
 									viewModel: viewModel)
 				} else {
-					FirstFeedLayout(entitys: viewModel.roleImage[index],
+					FirstFeedLayout(entityIndex: index,
+									entitys: viewModel.visibleRoleImages[index],
 									user: viewModel.users,
 									viewModel: viewModel)
 				}
 			} else {
 				if roleState == .all {
-					SecondFeedLayout(entitys: viewModel.images[index],
+					SecondFeedLayout(entityIndex: index,
+									 entitys: viewModel.visibleImages[index],
 									 user: viewModel.users,
 									 viewModel: viewModel)
 				} else {
-					SecondFeedLayout(entitys: viewModel.roleImage[index],
+					SecondFeedLayout(entityIndex: index,
+									 entitys: viewModel.visibleRoleImages[index],
 									 user: viewModel.users,
 									 viewModel: viewModel)
 				}

--- a/Yeowoo/Sources/Views/Album/AlbumFeedView.swift
+++ b/Yeowoo/Sources/Views/Album/AlbumFeedView.swift
@@ -166,7 +166,9 @@ private extension AlbumFeedView {
 					Alert(
 						title: Text("제목 수정"),
 						message: Text("앨범 제목을 수정했어요."),
-						dismissButton: .default(Text("확인")) { }
+						dismissButton: .default(Text("확인")) {
+							showingEditSheet = false
+						}
 					)
 				}
 				

--- a/Yeowoo/Sources/Views/Album/AlbumFeedView.swift
+++ b/Yeowoo/Sources/Views/Album/AlbumFeedView.swift
@@ -20,13 +20,16 @@ struct AlbumFeedView: View {
 	
 	@ObservedObject private var viewModel: AlbumViewModel
 	
-	@State private var layoutToggleState = false
+	@State private var layoutToggleState = true
 	@State private var nowSelectedUser: User? // 현재 역할이 선택된 유저
 	@State private var roleState: AlbumState = .all
 	@State private var showingFinishAlert = false
 	@State private var showingUpdateAlert = false
 	@State private var showingEditSheet = false
 	@State private var changedAlbumTitle = ""
+	
+	// sort 임시 토글
+	@State private var testSortToggle = true
 	
 	init(albumDocId: String, viewModel: AlbumViewModel) {
 		self.albumDocId = albumDocId
@@ -37,15 +40,21 @@ struct AlbumFeedView: View {
 		if viewModel.fetchState {
 			
 			CustomNavigationBar()
-
+			
 			ScrollView(showsIndicators: false) {
 				VStack {
-
+					
 					ProfileCarouselView()
 					
 					Spacer()
 						.frame(height: 24)
 					Divider()
+					
+					// sort 임시 토글
+					Toggle(isOn: self.$testSortToggle) { }
+						.onChange(of: testSortToggle) { newValue in
+							viewModel.imageSort(state: newValue)
+						}
 					
 					LazyVStack(pinnedViews: [.sectionHeaders]){
 						Section {
@@ -64,8 +73,8 @@ struct AlbumFeedView: View {
 					}
 				}
 			}
-            .navigationBarTitle("")
-            .navigationBarHidden(true)
+			.navigationBarTitle("")
+			.navigationBarHidden(true)
 		} else {
 			ProgressView()
 				.onAppear {

--- a/Yeowoo/Sources/Views/Album/Layouts/FirstFeedLayout.swift
+++ b/Yeowoo/Sources/Views/Album/Layouts/FirstFeedLayout.swift
@@ -42,15 +42,18 @@ struct FirstFeedLayout: View {
 					detailIndex = 0
 					isActive = true
 				} label: {
-					AsyncImage(url: URL(string: entitys[0].url)) { image in
-						image
-							.resizable()
-							.aspectRatio(contentMode: .fill)
-							.frame(width: width / 3, height: 250)
-							.cornerRadius(0)
-					} placeholder: {
-						ProgressView()
-							.frame(width: width / 3, height: 250)
+					CacheAsyncImage(url: URL(string: entitys[0].url)!) { phase in
+						switch phase {
+						case .success(let image):
+							image
+								.resizable()
+								.aspectRatio(contentMode: .fill)
+								.frame(width: width / 3, height: 250)
+								.cornerRadius(0)
+						default:
+							ProgressView()
+								.frame(width: width / 3, height: 250)
+						}
 					}
 				}
 				.overlay(
@@ -67,15 +70,18 @@ struct FirstFeedLayout: View {
 							detailIndex = 1
 							isActive = true
 						} label: {
-							AsyncImage(url: URL(string: entitys[1].url)) { image in
-								image
-									.resizable()
-									.aspectRatio(contentMode: .fill)
-									.frame(width: width / 3, height: 123)
-									.cornerRadius(0)
-							} placeholder: {
-								ProgressView()
-									.frame(width: width / 3, height: 123)
+							CacheAsyncImage(url: URL(string: entitys[1].url)!) { phase in
+								switch phase {
+								case .success(let image):
+									image
+										.resizable()
+										.aspectRatio(contentMode: .fill)
+										.frame(width: width / 3, height: 123)
+										.cornerRadius(0)
+								default:
+									ProgressView()
+										.frame(width: width / 3, height: 123)
+								}
 							}
 						}
 						.overlay(
@@ -91,15 +97,18 @@ struct FirstFeedLayout: View {
 							detailIndex = 2
 							isActive = true
 						} label: {
-							AsyncImage(url: URL(string: entitys[2].url)) { image in
-								image
-									.resizable()
-									.aspectRatio(contentMode: .fill)
-									.frame(width: width / 3, height: 123)
-									.cornerRadius(0)
-							} placeholder: {
-								ProgressView()
-									.frame(width: width / 3, height: 123)
+							CacheAsyncImage(url: URL(string: entitys[2].url)!) { phase in
+								switch phase {
+								case .success(let image):
+									image
+										.resizable()
+										.aspectRatio(contentMode: .fill)
+										.frame(width: width / 3, height: 123)
+										.cornerRadius(0)
+								default:
+									ProgressView()
+										.frame(width: width / 3, height: 123)
+								}
 							}
 						}
 						.overlay(
@@ -119,15 +128,18 @@ struct FirstFeedLayout: View {
 							detailIndex = 3
 							isActive = true
 						} label: {
-							AsyncImage(url: URL(string: entitys[3].url)) { image in
-								image
-									.resizable()
-									.aspectRatio(contentMode: .fill)
-									.frame(width: width / 3, height: 123)
-									.cornerRadius(0)
-							} placeholder: {
-								ProgressView()
-									.frame(width: width / 3, height: 123)
+							CacheAsyncImage(url: URL(string: entitys[3].url)!) { phase in
+								switch phase {
+								case .success(let image):
+									image
+										.resizable()
+										.aspectRatio(contentMode: .fill)
+										.frame(width: width / 3, height: 123)
+										.cornerRadius(0)
+								default:
+									ProgressView()
+										.frame(width: width / 3, height: 123)
+								}
 							}
 						}
 						.overlay(
@@ -143,15 +155,18 @@ struct FirstFeedLayout: View {
 							detailIndex = 4
 							isActive = true
 						} label: {
-							AsyncImage(url: URL(string: entitys[4].url)) { image in
-								image
-									.resizable()
-									.aspectRatio(contentMode: .fill)
-									.frame(width: width / 3, height: 123)
-									.cornerRadius(0)
-							} placeholder: {
-								ProgressView()
-									.frame(width: width / 3, height: 123)
+							CacheAsyncImage(url: URL(string: entitys[4].url)!) { phase in
+								switch phase {
+								case .success(let image):
+									image
+										.resizable()
+										.aspectRatio(contentMode: .fill)
+										.frame(width: width / 3, height: 123)
+										.cornerRadius(0)
+								default:
+									ProgressView()
+										.frame(width: width / 3, height: 123)
+								}
 							}
 						}
 						.overlay(

--- a/Yeowoo/Sources/Views/Album/Layouts/FirstFeedLayout.swift
+++ b/Yeowoo/Sources/Views/Album/Layouts/FirstFeedLayout.swift
@@ -15,13 +15,15 @@ struct FirstFeedLayout: View {
 	
 	private var entitys: [ImagesEntity]
 	private var user: [User]
+	private var entityIndex: Int
 	
 	@ObservedObject private var viewModel: AlbumViewModel
 	
 	@State private var detailIndex: Int = 0
 	@State private var isActive: Bool = false
 	
-	init(entitys: [ImagesEntity], user: [User], viewModel: AlbumViewModel) {
+	init(entityIndex: Int, entitys: [ImagesEntity], user: [User], viewModel: AlbumViewModel) {
+		self.entityIndex = entityIndex
 		self.entitys = entitys
 		self.user = user
 		self.viewModel = viewModel
@@ -30,7 +32,8 @@ struct FirstFeedLayout: View {
 	var body: some View {
 		NavigationLink (
 			destination:
-				AlbumDetailView(entitys: entitys[detailIndex],
+				AlbumDetailView(entityIndex: entityIndex,
+								entitys: entitys[detailIndex],
 								user: self.user.first(where: {$0.docId == entitys[detailIndex].uploadUser}) ?? User(),
 								tempLikeState: entitys[detailIndex].likeUsers.contains(UserDefaultsSetting.userDocId),
 								tempLikeCount: entitys[detailIndex].likeUsers.count,

--- a/Yeowoo/Sources/Views/Album/Layouts/GalleryLayout.swift
+++ b/Yeowoo/Sources/Views/Album/Layouts/GalleryLayout.swift
@@ -32,47 +32,50 @@ struct GalleryLayout: View {
 						detailIndex = index
 						isActive = true
 					} label: {
-						AsyncImage(url: URL(string: entitys[index].url)) { image in
-							image
-								.resizable()
-								.aspectRatio(contentMode: .fill)
-								.frame(width: UIScreen.main.bounds.width, height: 390)
-								.cornerRadius(0)
-								.overlay {
-									HStack(alignment: .bottom) {
-										Divider().opacity(0)
-										Text("\(entitys[index].comment)")
-											.font(.system(size: 14))
-											.foregroundColor(Color.white)
-										Spacer()
-										VStack {
-											Circle()
-												.fill(Color.white)
-												.opacity(0.25)
-												.frame(width: 48, height: 48)
-												.overlay {
-													Image(systemName: "heart.fill")
-														.foregroundColor(entitys[index].likeUsers.contains(UserDefaultsSetting.userDocId)
-																		 ? Color.red : Color.white)
-												}
-											Rectangle()
-												.fill(Color.white)
-												.opacity(0.25)
-												.frame(width: 48, height: 24)
-												.cornerRadius(100)
-												.overlay {
-													Text("\(entitys[index].likeUsers.count)")
-														.font(.system(size: 16, weight: .medium))
-														.foregroundColor(Color.white)
-												}
+						CacheAsyncImage(url: URL(string: entitys[index].url)!) { phase in
+							switch phase {
+							case .success(let image):
+								image
+									.resizable()
+									.aspectRatio(contentMode: .fill)
+									.frame(width: UIScreen.main.bounds.width, height: 390)
+									.cornerRadius(0)
+									.overlay {
+										HStack(alignment: .bottom) {
+											Divider().opacity(0)
+											Text("\(entitys[index].comment)")
+												.font(.system(size: 14))
+												.foregroundColor(Color.white)
+											Spacer()
+											VStack {
+												Circle()
+													.fill(Color.white)
+													.opacity(0.25)
+													.frame(width: 48, height: 48)
+													.overlay {
+														Image(systemName: "heart.fill")
+															.foregroundColor(entitys[index].likeUsers.contains(UserDefaultsSetting.userDocId)
+																			 ? Color.red : Color.white)
+													}
+												Rectangle()
+													.fill(Color.white)
+													.opacity(0.25)
+													.frame(width: 48, height: 24)
+													.cornerRadius(100)
+													.overlay {
+														Text("\(entitys[index].likeUsers.count)")
+															.font(.system(size: 16, weight: .medium))
+															.foregroundColor(Color.white)
+													}
+											}
 										}
+										.padding(.horizontal)
+										.padding(.bottom, 20)
 									}
-									.padding(.horizontal)
-									.padding(.bottom, 20)
-								}
-						} placeholder: {
-							ProgressView()
-								.frame(width: UIScreen.main.bounds.width, height: 390)
+							default:
+								ProgressView()
+									.frame(width: UIScreen.main.bounds.width, height: 390)
+							}
 						}
 					}
 					Spacer()

--- a/Yeowoo/Sources/Views/Album/Layouts/GalleryLayout.swift
+++ b/Yeowoo/Sources/Views/Album/Layouts/GalleryLayout.swift
@@ -16,70 +16,74 @@ struct GalleryLayout: View {
 	
 	var entitys: [ImagesEntity]
 	var user: [User]
+	var entityIndex: Int
 	
 	var body: some View {
-		ForEach(entitys.indices, id: \.self) { index in
-			NavigationLink(destination:
-							AlbumDetailView(entitys: entitys[detailIndex],
-											user: self.user.first(where: {$0.docId == entitys[detailIndex].uploadUser}) ?? User(),
-											tempLikeState: entitys[detailIndex].likeUsers.contains(UserDefaultsSetting.userDocId),
-											tempLikeCount: entitys[detailIndex].likeUsers.count,
-											viewModel: self.viewModel)
-						   ,isActive: $isActive
-			){
-				VStack(spacing: 0) {
-					Button {
-						detailIndex = index
-						isActive = true
-					} label: {
-						CacheAsyncImage(url: URL(string: entitys[index].url)!) { phase in
-							switch phase {
-							case .success(let image):
-								image
-									.resizable()
-									.aspectRatio(contentMode: .fill)
-									.frame(width: UIScreen.main.bounds.width, height: 390)
-									.cornerRadius(0)
-									.overlay {
-										HStack(alignment: .bottom) {
-											Divider().opacity(0)
-											Text("\(entitys[index].comment)")
-												.font(.system(size: 14))
-												.foregroundColor(Color.white)
-											Spacer()
-											VStack {
-												Circle()
-													.fill(Color.white)
-													.opacity(0.25)
-													.frame(width: 48, height: 48)
-													.overlay {
-														Image(systemName: "heart.fill")
-															.foregroundColor(entitys[index].likeUsers.contains(UserDefaultsSetting.userDocId)
-																			 ? Color.red : Color.white)
-													}
-												Rectangle()
-													.fill(Color.white)
-													.opacity(0.25)
-													.frame(width: 48, height: 24)
-													.cornerRadius(100)
-													.overlay {
-														Text("\(entitys[index].likeUsers.count)")
-															.font(.system(size: 16, weight: .medium))
-															.foregroundColor(Color.white)
-													}
+		LazyVStack {
+			ForEach(entitys.indices, id: \.self) { index in
+				NavigationLink(destination:
+								AlbumDetailView(entityIndex: entityIndex,
+												entitys: entitys[detailIndex],
+												user: self.user.first(where: {$0.docId == entitys[detailIndex].uploadUser}) ?? User(),
+												tempLikeState: entitys[detailIndex].likeUsers.contains(UserDefaultsSetting.userDocId),
+												tempLikeCount: entitys[detailIndex].likeUsers.count,
+												viewModel: self.viewModel)
+							   ,isActive: $isActive
+				){
+					VStack(spacing: 0) {
+						Button {
+							detailIndex = index
+							isActive = true
+						} label: {
+							CacheAsyncImage(url: URL(string: entitys[index].url)!) { phase in
+								switch phase {
+								case .success(let image):
+									image
+										.resizable()
+										.aspectRatio(contentMode: .fill)
+										.frame(width: UIScreen.main.bounds.width, height: 390)
+										.cornerRadius(0)
+										.overlay {
+											HStack(alignment: .bottom) {
+												Divider().opacity(0)
+												Text("\(entitys[index].comment)")
+													.font(.system(size: 14))
+													.foregroundColor(Color.white)
+												Spacer()
+												VStack {
+													Circle()
+														.fill(Color.white)
+														.opacity(0.25)
+														.frame(width: 48, height: 48)
+														.overlay {
+															Image(systemName: "heart.fill")
+																.foregroundColor(entitys[index].likeUsers.contains(UserDefaultsSetting.userDocId)
+																				 ? Color.red : Color.white)
+														}
+													Rectangle()
+														.fill(Color.white)
+														.opacity(0.25)
+														.frame(width: 48, height: 24)
+														.cornerRadius(100)
+														.overlay {
+															Text("\(entitys[index].likeUsers.count)")
+																.font(.system(size: 16, weight: .medium))
+																.foregroundColor(Color.white)
+														}
+												}
 											}
+											.padding(.horizontal)
+											.padding(.bottom, 20)
 										}
-										.padding(.horizontal)
-										.padding(.bottom, 20)
-									}
-							default:
-								ProgressView()
-									.frame(width: UIScreen.main.bounds.width, height: 390)
+								default:
+									ProgressView()
+										.frame(width: UIScreen.main.bounds.width, height: 390)
+								}
 							}
 						}
+						Spacer()
+							.frame(height: 2)
 					}
-					Spacer()
-						.frame(height: 2)
 				}
 			}
 		}

--- a/Yeowoo/Sources/Views/Album/Layouts/SecondFeedLayout.swift
+++ b/Yeowoo/Sources/Views/Album/Layouts/SecondFeedLayout.swift
@@ -39,15 +39,18 @@ struct SecondFeedLayout: View {
 						detailIndex = 0
 						isActive = true
 					} label: {
-						AsyncImage(url: URL(string: entitys[0].url)) { image in
-							image
-								.resizable()
-								.aspectRatio(contentMode: .fill)
-								.frame(width: width / 3, height: 123)
-								.cornerRadius(0)
-						} placeholder: {
-							ProgressView()
-								.frame(width: width / 3, height: 123)
+						CacheAsyncImage(url: URL(string: entitys[0].url)!) { phase in
+							switch phase {
+							case .success(let image):
+								image
+									.resizable()
+									.aspectRatio(contentMode: .fill)
+									.frame(width: width / 3, height: 123)
+									.cornerRadius(0)
+							default:
+								ProgressView()
+									.frame(width: width / 3, height: 123)
+							}
 						}
 					}
 					.overlay(
@@ -62,15 +65,18 @@ struct SecondFeedLayout: View {
 							detailIndex = 1
 							isActive = true
 						} label: {
-							AsyncImage(url: URL(string: entitys[1].url)) { image in
-								image
-									.resizable()
-									.aspectRatio(contentMode: .fill)
-									.frame(width: width / 3, height: 123)
-									.cornerRadius(0)
-							} placeholder: {
-								ProgressView()
-									.frame(width: width / 3, height: 123)
+							CacheAsyncImage(url: URL(string: entitys[1].url)!) { phase in
+								switch phase {
+								case .success(let image):
+									image
+										.resizable()
+										.aspectRatio(contentMode: .fill)
+										.frame(width: width / 3, height: 123)
+										.cornerRadius(0)
+								default:
+									ProgressView()
+										.frame(width: width / 3, height: 123)
+								}
 							}
 						}
 						.overlay(
@@ -90,15 +96,18 @@ struct SecondFeedLayout: View {
 							detailIndex = 2
 							isActive = true
 						} label: {
-							AsyncImage(url: URL(string: entitys[2].url)) { image in
-								image
-									.resizable()
-									.aspectRatio(contentMode: .fill)
-									.frame(width: width / 3, height: 123)
-									.cornerRadius(0)
-							} placeholder: {
-								ProgressView()
-									.frame(width: width / 3, height: 123)
+							CacheAsyncImage(url: URL(string: entitys[2].url)!) { phase in
+								switch phase {
+								case .success(let image):
+									image
+										.resizable()
+										.aspectRatio(contentMode: .fill)
+										.frame(width: width / 3, height: 123)
+										.cornerRadius(0)
+								default:
+									ProgressView()
+										.frame(width: width / 3, height: 123)
+								}
 							}
 						}
 						.overlay(
@@ -114,15 +123,18 @@ struct SecondFeedLayout: View {
 							detailIndex = 3
 							isActive = true
 						} label: {
-							AsyncImage(url: URL(string: entitys[3].url)) { image in
-								image
-									.resizable()
-									.aspectRatio(contentMode: .fill)
-									.frame(width: width / 3, height: 123)
-									.cornerRadius(0)
-							} placeholder: {
-								ProgressView()
-									.frame(width: width / 3, height: 123)
+							CacheAsyncImage(url: URL(string: entitys[3].url)!) { phase in
+								switch phase {
+								case .success(let image):
+									image
+										.resizable()
+										.aspectRatio(contentMode: .fill)
+										.frame(width: width / 3, height: 123)
+										.cornerRadius(0)
+								default:
+									ProgressView()
+										.frame(width: width / 3, height: 123)
+								}
 							}
 						}
 						.overlay(
@@ -140,15 +152,18 @@ struct SecondFeedLayout: View {
 						detailIndex = 4
 						isActive = true
 					} label: {
-						AsyncImage(url: URL(string: entitys[4].url)) { image in
-							image
-								.resizable()
-								.aspectRatio(contentMode: .fill)
-								.frame(width: width / 3, height: 250)
-								.cornerRadius(0)
-						} placeholder: {
-							ProgressView()
-								.frame(width: width / 3, height: 250)
+						CacheAsyncImage(url: URL(string: entitys[4].url)!) { phase in
+							switch phase {
+							case .success(let image):
+								image
+									.resizable()
+									.aspectRatio(contentMode: .fill)
+									.frame(width: width / 3, height: 250)
+									.cornerRadius(0)
+							default:
+								ProgressView()
+									.frame(width: width / 3, height: 250)
+							}
 						}
 					}
 					.overlay(

--- a/Yeowoo/Sources/Views/Album/Layouts/SecondFeedLayout.swift
+++ b/Yeowoo/Sources/Views/Album/Layouts/SecondFeedLayout.swift
@@ -11,13 +11,15 @@ struct SecondFeedLayout: View {
 	
 	private var entitys: [ImagesEntity]
 	private var user: [User]
+	private var entityIndex: Int
 	
 	@ObservedObject private var viewModel: AlbumViewModel
 	
 	@State private var detailIndex: Int = 0
 	@State private var isActive: Bool = false
 	
-	init(entitys: [ImagesEntity], user: [User], viewModel: AlbumViewModel) {
+	init(entityIndex: Int, entitys: [ImagesEntity], user: [User], viewModel: AlbumViewModel) {
+		self.entityIndex = entityIndex
 		self.entitys = entitys
 		self.user = user
 		self.viewModel = viewModel
@@ -26,7 +28,8 @@ struct SecondFeedLayout: View {
 	var body: some View {
 		NavigationLink (
 			destination:
-				AlbumDetailView(entitys: entitys[detailIndex],
+				AlbumDetailView(entityIndex: entityIndex,
+								entitys: entitys[detailIndex],
 								user: self.user.first(where: {$0.docId == entitys[detailIndex].uploadUser}) ?? User(),
 								tempLikeState: entitys[detailIndex].likeUsers.contains(UserDefaultsSetting.userDocId),
 								tempLikeCount: entitys[detailIndex].likeUsers.count,

--- a/Yeowoo/Sources/Views/Main/MainView.swift
+++ b/Yeowoo/Sources/Views/Main/MainView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct MainView: View {
 	
 	@ObservedObject var mainViewModel = MainViewModel()
+	@ObservedObject var albumViewModel = AlbumViewModel()
 	
 	var body: some View {
 		NavigationView {
@@ -83,7 +84,7 @@ struct MainView: View {
 									}
 									
 									NavigationLink(destination: {
-										AlbumFeedView(albumDocId: mainViewModel.albums[0].id, viewModel: AlbumViewModel())
+										AlbumFeedView(albumDocId: mainViewModel.albums[0].id, viewModel: albumViewModel)
 									}) {
 										// ViewModel에 userProfileImage 가져오는 메소드 추가
 										ZStack {
@@ -135,7 +136,7 @@ struct MainView: View {
 								ForEach(mainViewModel.albums[((mainViewModel.traveling == 1 || mainViewModel.traveling == 0) ? 1 : 0)..<mainViewModel.albums.count], id: \.self){ data in
 									
 									NavigationLink(destination: {
-										AlbumFeedView(albumDocId: data.id, viewModel: AlbumViewModel())
+										AlbumFeedView(albumDocId: data.id, viewModel: albumViewModel)
 									}) {
 										AlbumLayout(
 											userId: data.users,


### PR DESCRIPTION
# 작업내용
- 작업한 브랜치 : #36 

# 설명
- UT 피드백에 맞춰 디폴트 토글 순서를 변경했습니다.
- sort 버튼을 추가했습니다. 추후에 디자인이 픽스되면 UI 수정예정입니다.
- 이미지 캐시 처리했습니다.
- 페이지네이션 기능 추가했습니다.